### PR TITLE
Fixed typo and notation within Problem 3.23

### DIFF
--- a/Chapters/chapter3.tex
+++ b/Chapters/chapter3.tex
@@ -1419,11 +1419,15 @@ Are they linearly independent? Can the vector ${\bf y}=\left[\begin{array}{c} -1
 \label{2009_a5_2}
 Consider the following 4 dimensional vectors $\aa_1$, $\aa_2$, and $\aa_3$ such that
 $$
-a_1 = \left[\begin{array}{c} 1\\1\\0\\0 \end{array}\right] \qquad
-a_2 = \left[\begin{array}{c} 0\\0\\4\\-3 \end{array}\right] \qquad
-a_3 = \left[\begin{array}{c} 10\\0\\-5\\0 \end{array}\right]
+\aa_1 = \left[\begin{array}{c} 1\\1\\0\\0 \end{array}\right] \qquad
+\aa_2 = \left[\begin{array}{c} 0\\0\\4\\-3 \end{array}\right] \qquad
+\aa_3 = \left[\begin{array}{c} 10\\0\\-5\\0 \end{array}\right]
 $$
-Are these linearly independent? Can the vector $\boldmath{y}$ below be written as  linear combination of the above three vectors?
+Are these linearly independent? Can the vector ${\bf y}$ below be written as a 
+linear combination of the above three vectors?
+$$
+{\bf y} = \left[\begin{array}{c} 11\\1\\-1\\10 \end{array}\right]
+$$
 
 \end{problem}
 
@@ -3078,9 +3082,9 @@ which gives $x_2=7$, and $x_1 = 6$.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \vspace{2mm}
 \noindent {\bf Solution \ref{2009_a5_2}}
-The vectors $a_1$, $a_2$, and $a_3$ are linearly independent if the only solution to the system
+The vectors $\aa_1$, $\aa_2$, and $\aa_3$ are linearly independent if the only solution to the system
 $$
-x_1a_1 + x_2a_2 + x_3a_3 = 0
+x_1\aa_1 + x_2\aa_2 + x_3\aa_3 = 0
 $$
 is $x_1=x_2=x_3=0$
 So,
@@ -3094,14 +3098,17 @@ So,
 \end{eqnarray*}
 The system has a unique solution $x_1=x_2=x_3=0$, hence the three vectors are linearly independent.
 
-To find if $y$ can be written as a linear combination of the three vectors, we look for a solution of the system
+To find if ${\bf y}$ can be written as a linear combination of the three vectors, we look for a solution of the system
 \begin{eqnarray*}
 &&\left[\begin{array}{ccc|c}1&0&10&11 \\ 1&0&0&1 \\ 0&4&-5&-1 \\ 0&-3&0&10\end{array}\right]\rarr \begin{array}{c}(2,:)=(2,:)-(1,:)\\(3,:)=(3,:)+(4,:)\end{array}\rarr
 \left[\begin{array}{ccc|c}1&0&10&11 \\ 0&0&-10&-10 \\ 0&1&-5&9 \\ 0&-3&0&10\end{array}\right]\rarr\\
 &&\begin{array}{c}(2,:)=-\frac{1}{10}(2,:)\\(4,:)=(4,:)+3(3,:)\end{array}\rarr
 \left[\begin{array}{ccc|c}1&0&10&11 \\ 0&0&1&1 \\ 0&1&-5&9 \\ 0&0&-15&37\end{array}\right]
 \end{eqnarray*}
-The second row of the reduced row echelon matrix implies that $x_3=1$, while the third row yields that $x_3 = -\frac{37}{15}$. This contradiction means that the system has no solution, and $y$ is therefore not a linear combination of $a_1$, $a_2$, and $a_3$.
+The second row of the reduced row echelon matrix implies that $x_3=1$, 
+while the third row yields that $x_3 = -\frac{37}{15}$. This contradiction 
+means that the system has no solution, and ${\bf y}$ is therefore not a 
+linear combination of $\aa_1$, $\aa_2$, and $\aa_3$.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \vspace{2mm}


### PR DESCRIPTION
Fixed student reported typo; Problem 3.23 was missing a "y" vector.
Fixed inconsistent notation; now all vectors are in boldface.