### PR TITLE
Fixed typo about initial condition

### DIFF
--- a/Chapters/chapter6.tex
+++ b/Chapters/chapter6.tex
@@ -993,7 +993,7 @@ solution of the form (\ref{eq_gensoln}) for some choice of $c_1, c_2,
 \ldots, c_k$?
 
 There is a theorem in differential equations that says that given an
-initial condition $\xx_0$ there is one and only one solution of
+initial condition $\yy_0$ there is one and only one solution of
 $\yy' = A\yy$ satisfying $\yy(0)=\yy_0$.  So our theoretical question
 above is equivalent to the following quite practical question. Given
 an initial vector $\yy_0$, does there exist a solution $\yy(t)$ of the


### PR DESCRIPTION
The initial condition of a system of differential equations was mistakenly denoted x_0. This has been corrected to y_0.